### PR TITLE
Add compatibility with Python3.6 to hdiutil subprocess call

### DIFF
--- a/src/dmglib.py
+++ b/src/dmglib.py
@@ -72,7 +72,8 @@ def _raw_hdiutil(args, input: bytes = None) -> (int, bytes):
         raise FileNotFoundError('Unable to find hdituil.')
 
     completed = subprocess.run([HDIUTIL_PATH] + args,
-                               input=input, capture_output=True)
+                               input=input, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
 
     return (completed.returncode, completed.stdout)
 


### PR DESCRIPTION
`capture_output` kwarg is just an alias for `stdout=subprocess.PIPE` and `stderr=subprocess.PIPE` as [it is defined in `subprocess.run` function code](https://github.com/python/cpython/blob/4d2957c1b9a915f76da418e89bf9b5add141ca3e/Lib/subprocess.py#L495-L500).