### PR TITLE
Added: creating blank images

### DIFF
--- a/src/dmglib.py
+++ b/src/dmglib.py
@@ -421,7 +421,7 @@ class DMGStatus:
         self.mount_points = []
 
 
-def create_blank_dmg(
+def dmg_create_blank(
         path: str, disk_type: DiskCreateBlankFormat = None, fs_type: FsFormat = None, size=None,
         rename_sparse=False):
     """Creates blank DMG. Note: Doesn't construct the DiskImage object.

--- a/src/dmglib.py
+++ b/src/dmglib.py
@@ -446,7 +446,7 @@ def create_blank_dmg(
     if size == None:
         if disk_type != DiskCreateBlankFormat.SPARSEBUNDLE_IMAGE and disk_type != DiskCreateBlankFormat.SPARSE_IMAGE:
             raise CreatingFailed(
-                'Size is empty which is only supported for SPARSE_BUNDLE and SPARSE disk images.')
+                'Size is empty, which is only supported for SPARSE_BUNDLE and SPARSE disk images.')
 
     disk_type_str = disk_type.value if disk_type else None
     fs_type_str = fs_type.value if fs_type else None

--- a/src/dmglib.py
+++ b/src/dmglib.py
@@ -383,7 +383,7 @@ def create_blank_dmg(path: str, disk_type: DiskCreateBlankFormat=None, fs_type: 
         raise CreatingFailed('Specified image is alredy exists.')
 
     if disk_type == DiskCreateBlankFormat.SPARSE_IMAGE and os.path.exists(path + '.sparseimage'):
-        raise CreatingFailed('Specified image is alredy exists with `.sparseimage` extention, rename or remove it mannualy.')
+        raise CreatingFailed('Specified image is alredy exists with a `.sparseimage` extension, rename or remove it manualy.')
 
     if size == None:
         if disk_type != DiskCreateBlankFormat.SPARSEBUNDLE_IMAGE and disk_type != DiskCreateBlankFormat.SPARSE_IMAGE:

--- a/src/dmglib.py
+++ b/src/dmglib.py
@@ -343,7 +343,7 @@ class FsFormat(enum.Enum):
     MAC_OS_EXTENDED_CASE = 'Case-sensitive HFS+'
     MAC_OS_EXTENDED_CASE_JOUR = 'Case-sensitive Journaled HFS+'
     MAC_OS_EXTENDED_JOUR = 'Journaled HFS+'
-    ExFAT = 'ExFAT'
+    EXFAT = 'ExFAT'
     APFS_CASE = 'Case-sensitive APFS'
     APFS = 'APFS'
 
@@ -397,8 +397,8 @@ def create_blank_dmg(path: str, disk_type: DiskCreateBlankFormat=None, fs_type: 
     if not success:
         raise CreatingFailed()
 
-    created_image_path = created_image_path_dict[0]
     if disk_type == DiskCreateBlankFormat.SPARSE_IMAGE and rename_sparse:
+        created_image_path = created_image_path_dict[0]
         if created_image_path != path:
             os.rename(created_image_path, path)
 

--- a/src/dmglib.py
+++ b/src/dmglib.py
@@ -205,7 +205,7 @@ def _hdiutil_create(path, disk_type: str = None, fs_type: str = None, size: str 
         path: The disk image path.
         disk_type: Optional parameter to specify a disk type.
         fs_type: Optional parameter to specify a filesystem type.
-        size: Optional parameter to specify a image size.
+        size: Optional parameter to specify an image size.
 
     Returns:
         Tuple containing status code and dict with created image path, if successful.


### PR DESCRIPTION
# What's new

- Added `create_blank_dmg` and `_hdiutil_create` methods for creating blank DMG's
- Added `get_dmg_mountpoints` to get mountpoints of DMG without creating DiskImage object
- Added `detach_already_attached` to detach already attached DMG without creating DiskImage object (e.g. for creating it))
- Added `DiskCreateBlankFormat` and `FsFormat` enums
- Added `CreatingFailed` exception
- Removed extra spaces

# Verification

1. Creating blank growable APFS image:
```python
>>> from src import dmglib
>>> dmglib.create_blank_dmg("/tmp/test_apfs.dmg", disk_type=dmglib.DiskCreateBlankFormat.SPARSE_IMAGE, fs_type=dmglib.FsFormat.APFS)
>>> dmglib.dmg_is_valid("/tmp/test_apfs.dmg.sparseimage")
True
```

2. Creating already-exist image:
```python
>>> from src import dmglib
>>> dmglib.create_blank_dmg("/tmp/test_apfs.dmg", disk_type=dmglib.DiskCreateBlankFormat.SPARSE_IMAGE, fs_type=dmglib.FsFormat.APFS)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/drunkbatya/flipper/dmglib/src/dmglib.py", line 383, in create_blank_dmg
    raise CreatingFailed('Specified image is alredy exists.')
src.dmglib.CreatingFailed: Specified image is alredy exists.
```

3. `.sparseimage` postfix renaming and re-creation handling:
hdiutil creates growable images with a `.sparseimage` extension to the given name, e.g.:
```bash
$ hdiutil create -type SPARSE test.dmg
created: /Users/drunkbatya/flipper/dmglib/test.dmg.sparseimage
```

If we try to re-create image without extension. dmglib will raise an exception:
```python
>>> from src import dmglib
>>> dmglib.create_blank_dmg("/tmp/test_apfs.dmg", disk_type=dmglib.DiskCreateBlankFormat.SPARSE_IMAGE, fs_type=dmglib.FsFormat.APFS)
>>> dmglib.create_blank_dmg("/tmp/test_apfs.dmg", disk_type=dmglib.DiskCreateBlankFormat.SPARSE_IMAGE, fs_type=dmglib.FsFormat.APFS)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/drunkbatya/flipper/dmglib/src/dmglib.py", line 386, in create_blank_dmg
    raise CreatingFailed('Specified image is alredy exists with `.sparseimage` extension, rename or remove it manually.')
src.dmglib.CreatingFailed: Specified image is alredy exists with `.sparseimage` extension, rename or remove it manually.
```

But, sometimes we want to create growable images without `.sparseimage` extension, and now we can do it with the `rename_sparse` positional arg. Just set it to the True value (default=False)

```python
>>> from src import dmglib
>>> dmglib.create_blank_dmg("/tmp/test_apfs.dmg", disk_type=dmglib.DiskCreateBlankFormat.SPARSE_IMAGE, fs_type=dmglib.FsFormat.APFS, rename_sparse=True)
>>> dmglib.dmg_is_valid("/tmp/test_apfs.dmg")
True
```

4. Creating a DiskImage object of the already mounted image
Sometimes app uses dmglib may crash and leave already mounted DMG image, there was no way to detach using this lib, only manually:
```python
>>> from src import dmglib
>>> test = dmglib.DiskImage("/tmp/test.dmg")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/drunkbatya/flipper/dmglib/src/dmglib.py", line 479, in __init__
    raise AlreadyAttached()
src.dmglib.AlreadyAttached
```

But now we can do it using dmglib:
```python
>>> dmglib.detach_already_attached("/tmp/test.dmg")
>>> test = dmglib.DiskImage("/tmp/test.dmg")
```

# Other

I can't find any styling guide, probably i should re-format added code if you tell me how